### PR TITLE
Corrected user ids for created ads

### DIFF
--- a/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
@@ -2,6 +2,7 @@ package com.codeup.adlister.controllers;
 
 import com.codeup.adlister.dao.DaoFactory;
 import com.codeup.adlister.models.Ad;
+import com.codeup.adlister.models.User;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -24,8 +25,9 @@ public class CreateAdServlet extends HttpServlet {
 
 
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        User user = (User) request.getSession().getAttribute("user");
         Ad ad = new Ad(
-            1, // for now we'll hardcode the user id
+                user.getId(),
             request.getParameter("title"),
             request.getParameter("description")
         );

--- a/src/main/java/com/codeup/adlister/controllers/ViewProfileServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/ViewProfileServlet.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 @WebServlet(name = "controllers.ViewProfileServlet", urlPatterns = "/profile")
 public class ViewProfileServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        request.setAttribute("ads", DaoFactory.getAdsDao().findAllById();
+        request.setAttribute("ads", DaoFactory.getAdsDao().all());
         request.getRequestDispatcher("/WEB-INF/profile.jsp").forward(request, response);
 
         if (request.getSession().getAttribute("user") == null) {
@@ -24,3 +24,6 @@ public class ViewProfileServlet extends HttpServlet {
 
     }
 }
+
+
+

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
@@ -78,7 +78,7 @@ public class MySQLAdsDao implements Ads {
     public List<Ad> findAllById(long Id) {
         PreparedStatement stmt = null;
         try {
-            stmt = connection.prepareStatement("SELECT * FROM ads WHERE id = user_id");
+            stmt = connection.prepareStatement("SELECT * FROM ads WHERE user_id = id");
             ResultSet rs = stmt.executeQuery();
             return createAdsFromResults(rs);
         } catch (SQLException e) {


### PR DESCRIPTION
changed functionality in create-ad-servlet so that when a user creates an ad the user id for the ad will match with the user who created it.